### PR TITLE
Get access token from URL

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -35,6 +35,7 @@ jobs:
           touch .env.production
           echo "BASE_URL=/comms-app-react-videocall/" > .env.production
           echo "VITE_MUSIC_MODE=true" >> .env.production
+          echo "VITE_RTMP_STREAMING=false" >> .env.production
           yarn
           yarn build
           cp dist/index.html dist/404.html

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -36,6 +36,7 @@ jobs:
           echo "BASE_URL=/comms-app-react-videocall/" > .env.production
           echo "VITE_MUSIC_MODE=true" >> .env.production
           echo "VITE_RTMP_STREAMING=false" >> .env.production
+          echo "VITE_ENABLE_UNGATED_FEATURES=false" >> .env.production
           yarn
           yarn build
           cp dist/index.html dist/404.html

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@dolbyio/comms-uikit-react": "1.2.0",
     "@emotion/react": "^11.9.0",
-    "@voxeet/voxeet-web-sdk": "^3.10.0",
+    "@voxeet/voxeet-web-sdk": "^3.11.0",
     "axios": "^0.26.1",
     "classnames": "^2.3.1",
     "color": "4.2.3",

--- a/src/hooks/useToken.ts
+++ b/src/hooks/useToken.ts
@@ -6,7 +6,10 @@ import fetch from '../utils/fetch';
 const useToken = () => {
   const [error, setError] = useState<string | undefined>();
 
-  const accessToken = import.meta.env.VITE_CLIENT_ACCESS_TOKEN || '';
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlAccessToken = urlParams.get('token');
+
+  const accessToken = import.meta.env.VITE_CLIENT_ACCESS_TOKEN || urlAccessToken || '';
 
   const [YOUR_TOKEN, setToken] = useState<string | null>(null);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@
     "@babel/plugin-transform-react-jsx-source" "^7.22.5"
     react-refresh "^0.14.0"
 
-"@voxeet/voxeet-web-sdk@^3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@voxeet/voxeet-web-sdk/-/voxeet-web-sdk-3.10.0.tgz#5f2bb3878b3bf9a779bce8b1cd8ed81dd36d28ad"
-  integrity sha512-L8ALer7B2g6CCRx4zMlJg7YzKmO07u96V9cm4Cj0ayd37AQMPojinS7XrVTx5Dfh/lgOJQjnU6fhyZKAlNuwvg==
+"@voxeet/voxeet-web-sdk@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@voxeet/voxeet-web-sdk/-/voxeet-web-sdk-3.11.0.tgz#4bfcee5172787c7e3b93cd543a958974c0417ea1"
+  integrity sha512-ltQ0E8EzHTJxJXl63IFqw6hSs9fzwF9DiV7jtudfKaQxrNDBDEDIE3vUjlxQZlKGfjLoeODfCFezxyjbB0tXNA==
   dependencies:
     axios "^0.26.0"
     bowser "^2.8.1"


### PR DESCRIPTION
When this web app is loaded from the Dolby.io dashboard, use the access token from the URL and disable RTMP streaming.
Enable recording of the conference.
Also, upgrade the SDK to 3.11.0